### PR TITLE
Fixed (Added) characters that were beign used to split the file name.

### DIFF
--- a/bot/helper/drive_utils/gdriveTools.py
+++ b/bot/helper/drive_utils/gdriveTools.py
@@ -89,7 +89,7 @@ class GoogleDriveHelper:
                 query += "mimeType = 'application/vnd.google-apps.folder' and "
             elif search_type == '-f':
                 query += "mimeType != 'application/vnd.google-apps.folder' and "
-        var=re.split('[ ._]',fileName)
+        var=re.split('[ ._,\\[\\]-]',fileName)
         for text in var:
             query += f"name contains '{text}' and "
         query += "trashed=false"
@@ -147,7 +147,7 @@ class GoogleDriveHelper:
         content_count = 0
         reached_max_limit = False
         add_title_msg = True
-        var=re.split('[ ._,]',fileName)
+        var=re.split('[ ._,\\[\\]-]',fileName)
         pattern = ""
         for i in var:
             pattern += f"(?=.*{i})"
@@ -189,7 +189,7 @@ class GoogleDriveHelper:
                                 msg += f'<b> | <a href="{url}">Index link</a></b>'
                         msg += '<br><br>'
                         content_count += 1
-                    if (content_count==TELEGRAPHLIMIT):
+                    if (content_count >= TELEGRAPHLIMIT):
                         reached_max_limit = True
                       
                     

--- a/bot/helper/drive_utils/gdriveTools.py
+++ b/bot/helper/drive_utils/gdriveTools.py
@@ -73,10 +73,10 @@ class GoogleDriveHelper:
         while(y != rootid):
             rtnlist.append(x)
             file = self.__service.files().get(
-                                            fileId=file.get("parents")[0],
-                                            supportsAllDrives=True,
-                                            fields='id, name, parents'
-                                            ).execute()
+                fileId=file.get("parents")[0],
+                supportsAllDrives=True,
+                fields='id, name, parents'
+            ).execute()
             x = file.get("name")
             y = file.get("id")
         rtnlist.reverse()
@@ -95,24 +95,24 @@ class GoogleDriveHelper:
         query += "trashed=false"
         if parent_id != "root":
             response = self.__service.files().list(supportsTeamDrives=True,
-                                               includeTeamDriveItems=True,
-                                               teamDriveId=parent_id,
-                                               q=query,
-                                               corpora='drive',
-                                               spaces='drive',
-                                               pageSize=1000,
-                                               fields='files(id, name, mimeType, size, teamDriveId, parents)',
-                                               orderBy='folder, modifiedTime desc').execute()["files"]
+                                                   includeTeamDriveItems=True,
+                                                   teamDriveId=parent_id,
+                                                   q=query,
+                                                   corpora='drive',
+                                                   spaces='drive',
+                                                   pageSize=1000,
+                                                   fields='files(id, name, mimeType, size, teamDriveId, parents)',
+                                                   orderBy='folder, modifiedTime desc').execute()["files"]
         else:
             response = self.__service.files().list(q=query + " and 'me' in owners",
-                                               pageSize=1000,
-                                               spaces='drive',
-                                               fields='files(id, name, mimeType, size, parents)',
-                                               orderBy='folder, modifiedTime desc').execute()["files"]
+                                                   pageSize=1000,
+                                                   spaces='drive',
+                                                   fields='files(id, name, mimeType, size, parents)',
+                                                   orderBy='folder, modifiedTime desc').execute()["files"]
         return response
 
     def edit_telegraph(self):
-        nxt_page = 1 
+        nxt_page = 1
         prev_page = 0
         for content in self.telegraph_content :
             if nxt_page == 1 :
@@ -147,82 +147,68 @@ class GoogleDriveHelper:
         content_count = 0
         reached_max_limit = False
         add_title_msg = True
-        var=re.split('[ ._,\\[\\]-]',fileName)
-        pattern = ""
-        for i in var:
-            pattern += f"(?=.*{i})"
-        pattern += ".*$"
         for parent_id in DRIVE_ID :
             add_drive_title = True
             response = self.drive_query(parent_id, search_type, fileName)
             #LOGGER.info(f"my a: {response}")
-            
-            
-            INDEX += 1          
+
+            INDEX += 1
             if response:
-                
-                
+
                 for file in response:
-                    
-                    x = re.search(pattern, file.get('name'),re.IGNORECASE)
-                    
-                    if x:
-                        if add_title_msg == True:
-                            msg = f'<h3>I found: {fileName}</h3><br><b><a href="https://github.com/AnimeKaizoku/ArchivistsBot"> Bot Repo </a></b> || @TheArchivists'
-                            add_title_msg = False
-                        if add_drive_title == True:
-                            msg += f"╾────────────╼<br><b>{DRIVE_NAME[INDEX]}</b><br>╾────────────╼<br>"
-                            add_drive_title = False
-                        if file.get('mimeType') == "application/vnd.google-apps.folder":  # Detect Whether Current Entity is a Folder or File.
-                            msg += f"🗃️<code>{file.get('name')}</code> <b>(folder)</b><br>" \
-                                   f"<b><a href='https://drive.google.com/drive/folders/{file.get('id')}'>Google Drive link</a></b>"
-                            if INDEX_URL[INDEX] is not None:
-                                url_path = "/".join([requests.utils.quote(n, safe='') for n in self.get_recursive_list(file, parent_id)])
-                                url = f'{INDEX_URL[INDEX]}/{url_path}/'
-                                msg += f'<b> | <a href="{url}">Index link</a></b>'
-                        else:
-                            msg += f"<code>{file.get('name')}</code> <b>({self.get_readable_file_size(file.get('size'))})</b><br>" \
-                                   f"<b><a href='https://drive.google.com/uc?id={file.get('id')}&export=download'>Google Drive link</a></b>"
-                            if INDEX_URL[INDEX] is not None:
-                                url_path = "/".join([requests.utils.quote(n, safe ='') for n in self.get_recursive_list(file, parent_id)])
-                                url = f'{INDEX_URL[INDEX]}/{url_path}'
-                                msg += f'<b> | <a href="{url}">Index link</a></b>'
-                        msg += '<br><br>'
-                        content_count += 1
+
+                    if add_title_msg == True:
+                        msg = f'<h3>I found: {fileName}</h3><br><b><a href="https://github.com/AnimeKaizoku/ArchivistsBot"> Bot Repo </a></b> || @TheArchivists'
+                        add_title_msg = False
+                    if add_drive_title == True:
+                        msg += f"╾────────────╼<br><b>{DRIVE_NAME[INDEX]}</b><br>╾────────────╼<br>"
+                        add_drive_title = False
+                    if file.get('mimeType') == "application/vnd.google-apps.folder":  # Detect Whether Current Entity is a Folder or File.
+                        msg += f"🗃️<code>{file.get('name')}</code> <b>(folder)</b><br>" \
+                               f"<b><a href='https://drive.google.com/drive/folders/{file.get('id')}'>Google Drive link</a></b>"
+                        if INDEX_URL[INDEX] is not None:
+                            url_path = "/".join([requests.utils.quote(n, safe='') for n in self.get_recursive_list(file, parent_id)])
+                            url = f'{INDEX_URL[INDEX]}/{url_path}/'
+                            msg += f'<b> | <a href="{url}">Index link</a></b>'
+                    else:
+                        msg += f"<code>{file.get('name')}</code> <b>({self.get_readable_file_size(file.get('size'))})</b><br>" \
+                               f"<b><a href='https://drive.google.com/uc?id={file.get('id')}&export=download'>Google Drive link</a></b>"
+                        if INDEX_URL[INDEX] is not None:
+                            url_path = "/".join([requests.utils.quote(n, safe ='') for n in self.get_recursive_list(file, parent_id)])
+                            url = f'{INDEX_URL[INDEX]}/{url_path}'
+                            msg += f'<b> | <a href="{url}">Index link</a></b>'
+                    msg += '<br><br>'
+                    content_count += 1
                     if (content_count >= TELEGRAPHLIMIT):
                         reached_max_limit = True
-                      
-                    
+
+
                         LOGGER.info(f"my a: {content_count}")
                         #self.telegraph_content.append(msg)
                         #msg = ""
                         #content_count = 0
                         break
 
-        
         if msg != '':
             self.telegraph_content.append(msg)
-            
+
         if len(self.telegraph_content) == 0:
             return "I ..I found nothing of that sort :(", None
-      
-            
-        
 
         for content in self.telegraph_content :
             self.path.append(telegra_ph.create_page(title = '♙ The Archivists • 04 • Dragonia',
-                                                html_content=content )['path'])
+                                                    html_content=content )['path'])
 
-        self.num_of_path = len(self.path)      
+        self.num_of_path = len(self.path)
         if self.num_of_path > 1:
             self.edit_telegraph()
-        
+
         msg = f"Found {content_count}" + ("+" if content_count >= 95 else "") + " results"
-        
+
         if reached_max_limit:
             msg += ". (Only showing top 95 results. Omitting remaining results)"
-        
-        buttons = button_builder.ButtonMaker()   
+
+        buttons = button_builder.ButtonMaker()
         buttons.buildbutton("Click Here for results", f"https://telegra.ph/{self.path[0]}")
 
         return msg, InlineKeyboardMarkup(buttons.build_menu(1))


### PR DESCRIPTION
If the fileName has something like [AABBCC-aa] than previously, up split, the open and close squre brackets would remain there. But they have a special meaning in regEx, so it was giving an error.